### PR TITLE
chore(ci): use trusted npm publishing via gh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,9 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
-      - devel
+    branches: [master, devel]
   pull_request:
-    branches:
-      - master
-      - devel
+    branches: [master, devel]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'v24.11.1'
-          registry-url: 'https://npm.pkg.github.com'
           scope: '@joinmarket-webui'
 
       - name: Install
@@ -32,11 +31,11 @@ jobs:
         run: npm run build
 
       - name: Publish to npm Registry
-        run: npm run publish:npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          npm run publish:npm
 
       - name: Publish to Github Registry
-        run: npm run publish:ghr
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
+          npm run publish:ghr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release:
     permissions:
+      id-token: write
       contents: write
       packages: write
 
@@ -31,9 +32,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm Registry
-        run: |
-          npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-          npm run publish:npm
+        run: npm run publish:npm
 
       - name: Publish to Github Registry
         run: |

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "openapi-ts:fetch-schema": "wget https://joinmarket-org.github.io/joinmarket-clientserver/api/wallet-rpc.yaml -O ./contrib/jm-wallet-rpc.yaml",
     "openapi-ts": "openapi-ts",
     "example": "npx tsx ./example.ts",
-    "publish:npm": "npm publish --access public --@joinmarket-webui:registry=https://registry.npmjs.org",
-    "publish:ghr": "npm publish --access public --@joinmarket-webui:registry=https://npm.pkg.github.com"
+    "publish:npm": "npm publish --ignore-scripts --access public --@joinmarket-webui:registry=https://registry.npmjs.org",
+    "publish:ghr": "npm publish --ignore-scripts --access public --@joinmarket-webui:registry=https://npm.pkg.github.com"
   },
   "homepage": "https://github.com/joinmarket-webui/joinmarket-api-ts",
   "repository": {


### PR DESCRIPTION
Setup trusted publishing for `release.yml` workflow: https://docs.npmjs.com/trusted-publishers


This must still be tested and might not work properly. We'll see with the next release.